### PR TITLE
added a new mode for all parsers : "strict" mode which is the default…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fr.noop</groupId>
     <artifactId>subtitle</artifactId>
-    <version>0.9.0</version>
+    <version>0.9.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>subtitle</name>
     <description>

--- a/src/main/java/fr/noop/subtitle/Convert.java
+++ b/src/main/java/fr/noop/subtitle/Convert.java
@@ -166,6 +166,14 @@ public class Convert {
                 .hasArg()
                 .desc("Output charset")
                 .build());
+        
+
+        // Output charset option
+        this.options.addOption(Option.builder("dsm")
+                .required(false)
+                .longOpt("disable-strict-mode")
+                .desc("Disable strict mode")
+                .build());
     }
 
     public Convert() {
@@ -202,6 +210,7 @@ public class Convert {
             String outputFilePath = line.getOptionValue("o");
             String inputCharset = line.getOptionValue("ic", "utf-8");
             String outputCharset = line.getOptionValue("oc", "utf-8");
+            boolean disableStrictMode = line.hasOption("disable-strict-mode");
 
             // Build parser for input file
             SubtitleParser subtitleParser = null;
@@ -227,7 +236,7 @@ public class Convert {
             SubtitleObject inputSubtitle = null;
 
             try {
-                inputSubtitle = subtitleParser.parse(is);
+                inputSubtitle = subtitleParser.parse(is, !disableStrictMode);
             } catch (IOException e) {
                 System.out.println(String.format("Unable ro read input file %s: %s", inputFilePath, e.getMessage()));
                 System.exit(1);

--- a/src/main/java/fr/noop/subtitle/model/SubtitleParser.java
+++ b/src/main/java/fr/noop/subtitle/model/SubtitleParser.java
@@ -10,8 +10,6 @@
 
 package fr.noop.subtitle.model;
 
-import fr.noop.subtitle.base.BaseSubtitleObject;
-
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -20,4 +18,5 @@ import java.io.InputStream;
  */
 public interface SubtitleParser {
     public SubtitleObject parse(InputStream is) throws IOException, SubtitleParsingException;
+    public SubtitleObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException;
 }

--- a/src/main/java/fr/noop/subtitle/sami/SamiParser.java
+++ b/src/main/java/fr/noop/subtitle/sami/SamiParser.java
@@ -10,18 +10,16 @@
 
 package fr.noop.subtitle.sami;
 
-import fr.noop.subtitle.model.SubtitleParser;
-import fr.noop.subtitle.model.SubtitleParsingException;
-import fr.noop.subtitle.srt.SrtCue;
-import fr.noop.subtitle.srt.SrtObject;
-import fr.noop.subtitle.util.SubtitlePlainText;
-import fr.noop.subtitle.util.SubtitleTextLine;
-import fr.noop.subtitle.util.SubtitleTimeCode;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
+import fr.noop.subtitle.model.SubtitleParser;
+import fr.noop.subtitle.model.SubtitleParsingException;
+import fr.noop.subtitle.util.SubtitlePlainText;
+import fr.noop.subtitle.util.SubtitleTextLine;
+import fr.noop.subtitle.util.SubtitleTimeCode;
 
 /**
  * Created by clebeaupin on 11/10/15.
@@ -41,8 +39,14 @@ public class SamiParser implements SubtitleParser {
         this.charset = charset;
     }
 
+
     @Override
     public SamiObject parse(InputStream is) throws IOException, SubtitleParsingException {
+    	return parse(is, true);
+    }
+    
+    @Override
+    public SamiObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException {
         // Create SAMI object
         SamiObject samiObject = new SamiObject();
 

--- a/src/main/java/fr/noop/subtitle/sami/SamiWriter.java
+++ b/src/main/java/fr/noop/subtitle/sami/SamiWriter.java
@@ -10,15 +10,13 @@
 
 package fr.noop.subtitle.sami;
 
-import fr.noop.subtitle.base.BaseSubtitleObject;
-import fr.noop.subtitle.model.SubtitleCue;
-import fr.noop.subtitle.model.SubtitleObject;
-import fr.noop.subtitle.model.SubtitleWriter;
-import fr.noop.subtitle.util.SubtitleTimeCode;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+
+import fr.noop.subtitle.model.SubtitleCue;
+import fr.noop.subtitle.model.SubtitleObject;
+import fr.noop.subtitle.model.SubtitleWriter;
 
 /**
  * Created by clebeaupin on 11/10/15.

--- a/src/main/java/fr/noop/subtitle/srt/SrtParser.java
+++ b/src/main/java/fr/noop/subtitle/srt/SrtParser.java
@@ -10,16 +10,16 @@
 
 package fr.noop.subtitle.srt;
 
-import fr.noop.subtitle.model.SubtitleParsingException;
-import fr.noop.subtitle.model.SubtitleParser;
-import fr.noop.subtitle.util.SubtitleTextLine;
-import fr.noop.subtitle.util.SubtitlePlainText;
-import fr.noop.subtitle.util.SubtitleTimeCode;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
+import fr.noop.subtitle.model.SubtitleParser;
+import fr.noop.subtitle.model.SubtitleParsingException;
+import fr.noop.subtitle.util.SubtitlePlainText;
+import fr.noop.subtitle.util.SubtitleTextLine;
+import fr.noop.subtitle.util.SubtitleTimeCode;
 
 /**
  * Created by clebeaupin on 21/09/15.
@@ -40,6 +40,11 @@ public class SrtParser implements SubtitleParser {
 
     @Override
     public SrtObject parse(InputStream is) throws IOException, SubtitleParsingException {
+    	return parse(is, true);
+    }
+    
+    @Override
+    public SrtObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException {
         // Create srt object
         SrtObject srtObject = new SrtObject();
 

--- a/src/main/java/fr/noop/subtitle/stl/StlParser.java
+++ b/src/main/java/fr/noop/subtitle/stl/StlParser.java
@@ -10,17 +10,20 @@
 
 package fr.noop.subtitle.stl;
 
-import fr.noop.subtitle.model.SubtitleParser;
-import fr.noop.subtitle.model.SubtitleParsingException;
-import fr.noop.subtitle.util.SubtitleTimeCode;
-
-import org.apache.commons.lang3.StringUtils;
-
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+
+import org.apache.commons.lang3.StringUtils;
+
+import fr.noop.subtitle.model.SubtitleParser;
+import fr.noop.subtitle.model.SubtitleParsingException;
+import fr.noop.subtitle.util.SubtitleTimeCode;
 
 /**
  * Created by clebeaupin on 21/09/15.
@@ -28,8 +31,12 @@ import java.util.Date;
 public class StlParser implements SubtitleParser {
     public StlParser() {
     }
-
+    
     public StlObject parse(InputStream is) throws SubtitleParsingException {
+    	return parse(is, true);
+    }
+
+    public StlObject parse(InputStream is, boolean strict) throws SubtitleParsingException {
         BufferedInputStream bis = new BufferedInputStream(is);
         DataInputStream dis = new DataInputStream(bis);
 


### PR DESCRIPTION
Added a new mode for all parsers : "strict" mode which is the default one (use --disable-strict-mode on the command line to disable it)

WebVTT parser now allows empty subtitle if not using "strict" mode
upgraded version to developement 0.9.1-SNAPSHOT

We needed to add this to be able to use ARTE France legacy subtitles which contains such "empty" subtitle at the very beginning of the file.
