### PR TITLE
ajout gestion offset : option -so à ajouter si besoin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fr.noop</groupId>
     <artifactId>subtitle</artifactId>
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>subtitle</name>
     <description>

--- a/src/main/java/fr/noop/subtitle/Convert.java
+++ b/src/main/java/fr/noop/subtitle/Convert.java
@@ -167,12 +167,19 @@ public class Convert {
                 .desc("Output charset")
                 .build());
         
-
         // Output charset option
         this.options.addOption(Option.builder("dsm")
                 .required(false)
                 .longOpt("disable-strict-mode")
                 .desc("Disable strict mode")
+                .build());
+
+        // Output charset option
+        this.options.addOption(Option.builder("so")
+                .required(false)
+                .longOpt("offset")
+                .hasArg()
+                .desc("Subtitles offset")
                 .build());
     }
 
@@ -211,12 +218,13 @@ public class Convert {
             String inputCharset = line.getOptionValue("ic", "utf-8");
             String outputCharset = line.getOptionValue("oc", "utf-8");
             boolean disableStrictMode = line.hasOption("disable-strict-mode");
+            int subtitleOffset = Integer.parseInt(line.getOptionValue("so", "0"));
 
             // Build parser for input file
             SubtitleParser subtitleParser = null;
 
             try {
-                subtitleParser = this.buildParser(inputFilePath, inputCharset);
+                subtitleParser = this.buildParser(inputFilePath, inputCharset, subtitleOffset);
             } catch(IOException e) {
                 System.out.println(String.format("Unable to build parser for file %s: %s", inputFilePath, e.getMessage()));
                 System.exit(1);
@@ -236,7 +244,7 @@ public class Convert {
             SubtitleObject inputSubtitle = null;
 
             try {
-                inputSubtitle = subtitleParser.parse(is, !disableStrictMode);
+                inputSubtitle = subtitleParser.parse(is, subtitleOffset, !disableStrictMode);
             } catch (IOException e) {
                 System.out.println(String.format("Unable ro read input file %s: %s", inputFilePath, e.getMessage()));
                 System.exit(1);
@@ -279,7 +287,7 @@ public class Convert {
         }
     }
 
-    private SubtitleParser buildParser(String filePath, String charset) throws IOException {
+    private SubtitleParser buildParser(String filePath, String charset, int offset) throws IOException {
         String ext = this.getFileExtension(filePath);
 
         // Get subtitle parser class

--- a/src/main/java/fr/noop/subtitle/model/SubtitleParser.java
+++ b/src/main/java/fr/noop/subtitle/model/SubtitleParser.java
@@ -19,4 +19,5 @@ import java.io.InputStream;
 public interface SubtitleParser {
     public SubtitleObject parse(InputStream is) throws IOException, SubtitleParsingException;
     public SubtitleObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException;
+    public SubtitleObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException;
 }

--- a/src/main/java/fr/noop/subtitle/model/SubtitleWriter.java
+++ b/src/main/java/fr/noop/subtitle/model/SubtitleWriter.java
@@ -10,8 +10,6 @@
 
 package fr.noop.subtitle.model;
 
-import fr.noop.subtitle.base.BaseSubtitleObject;
-
 import java.io.IOException;
 import java.io.OutputStream;
 

--- a/src/main/java/fr/noop/subtitle/sami/SamiParser.java
+++ b/src/main/java/fr/noop/subtitle/sami/SamiParser.java
@@ -42,11 +42,16 @@ public class SamiParser implements SubtitleParser {
 
     @Override
     public SamiObject parse(InputStream is) throws IOException, SubtitleParsingException {
-    	return parse(is, true);
+    	return parse(is, 0, true);
     }
     
     @Override
     public SamiObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException {
+    	return this.parse(is, 0, strict);
+    }
+    
+    @Override
+    public SamiObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException {
         // Create SAMI object
         SamiObject samiObject = new SamiObject();
 
@@ -103,7 +108,7 @@ public class SamiParser implements SubtitleParser {
                 long time;
 
                 try {
-                    time = Long.valueOf(startTime);
+                    time = Long.valueOf(startTime + subtitleOffset);
                 } catch (NumberFormatException e) {
                     throw new SubtitleParsingException(String.format(
                             "Unable to parse start time: %s",
@@ -155,7 +160,7 @@ public class SamiParser implements SubtitleParser {
         // Set end time for the last cue
         if (previousCue != null) {
             // Last cue duration is 2s
-            previousCue.setEndTime(new SubtitleTimeCode(previousCue.getStartTime().getTime() + 2000));
+            previousCue.setEndTime(new SubtitleTimeCode(previousCue.getStartTime().getTime() + 2000 + subtitleOffset));
         }
 
         return samiObject;

--- a/src/main/java/fr/noop/subtitle/srt/SrtParser.java
+++ b/src/main/java/fr/noop/subtitle/srt/SrtParser.java
@@ -40,11 +40,16 @@ public class SrtParser implements SubtitleParser {
 
     @Override
     public SrtObject parse(InputStream is) throws IOException, SubtitleParsingException {
-    	return parse(is, true);
+    	return parse(is, 0, true);
     }
     
     @Override
     public SrtObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException {
+    	return this.parse(is, 0, strict);
+    }
+    
+    @Override
+    public SrtObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException {
         // Create srt object
         SrtObject srtObject = new SrtObject();
 
@@ -87,8 +92,8 @@ public class SrtParser implements SubtitleParser {
                             "Timecode textLine is badly formated: %s", textLine));
                 }
 
-                cue.setStartTime(this.parseTimeCode(textLine.substring(0, 12)));
-                cue.setEndTime(this.parseTimeCode(textLine.substring(17)));
+                cue.setStartTime(this.parseTimeCode(textLine.substring(0, 12), subtitleOffset));
+                cue.setEndTime(this.parseTimeCode(textLine.substring(17), subtitleOffset));
                 cursorStatus = CursorStatus.CUE_TIMECODE;
                 continue;
             }
@@ -119,13 +124,13 @@ public class SrtParser implements SubtitleParser {
         return srtObject;
     }
 
-    private SubtitleTimeCode parseTimeCode(String timeCodeString) throws SubtitleParsingException {
+    private SubtitleTimeCode parseTimeCode(String timeCodeString, int subtitleOffset) throws SubtitleParsingException {
         try {
             int hour = Integer.parseInt(timeCodeString.substring(0, 2));
             int minute = Integer.parseInt(timeCodeString.substring(3, 5));
             int second = Integer.parseInt(timeCodeString.substring(6, 8));
             int millisecond = Integer.parseInt(timeCodeString.substring(9, 12));
-            return new SubtitleTimeCode(hour, minute, second, millisecond);
+            return new SubtitleTimeCode(hour, minute, second, millisecond, subtitleOffset);
         } catch (NumberFormatException e) {
             throw new SubtitleParsingException(String.format(
                     "Unable to parse time code: %s", timeCodeString));

--- a/src/main/java/fr/noop/subtitle/util/SubtitleTimeCode.java
+++ b/src/main/java/fr/noop/subtitle/util/SubtitleTimeCode.java
@@ -17,6 +17,7 @@ import java.time.LocalTime;
  * Created by clebeaupin on 22/09/15.
  */
 public class SubtitleTimeCode implements Comparable<SubtitleTimeCode> {
+	private final int MAX_HOUR = 24;
     private final int MS_HOUR = 3600000;
     private final int MS_MINUTE = 60000;
     private final int MS_SECOND = 1000;
@@ -25,15 +26,28 @@ public class SubtitleTimeCode implements Comparable<SubtitleTimeCode> {
     private int second;
     private int millisecond;
 
+    public SubtitleTimeCode(int hour, int minute, int second, int millisecond, int offset) {
+    	int newTime = hour*MS_HOUR+minute*MS_MINUTE+second*MS_SECOND+millisecond + offset;
+        
+        int newHour = (int) ((newTime/MS_HOUR)%MAX_HOUR);
+        int minuteOffsetRest = newTime%MS_HOUR;
+    	int newMinute = (int) (minuteOffsetRest/MS_MINUTE);
+    	int secondOffsetRest = minuteOffsetRest%MS_MINUTE;
+    	int newSecond = (int) (secondOffsetRest/MS_SECOND);
+    	int newMillisecond = secondOffsetRest%MS_SECOND;  
+    	
+    	this.setHour(newHour);
+        this.setMinute(newMinute);
+        this.setSecond(newSecond);
+        this.setMillisecond(newMillisecond);
+    }
+
     public SubtitleTimeCode(int hour, int minute, int second, int millisecond) {
-        this.setHour(hour);
-        this.setMinute(minute);
-        this.setSecond(second);
-        this.setMillisecond(millisecond);
+    	this(hour, minute, second, millisecond, 0);
     }
 
     public SubtitleTimeCode(LocalTime time) {
-        this(time.getHour(), time.getMinute(), time.getSecond(), 0);
+        this(time.getHour(), time.getMinute(), time.getSecond(), 0, 0);
     }
 
     /**
@@ -99,7 +113,7 @@ public class SubtitleTimeCode implements Comparable<SubtitleTimeCode> {
 
         this.millisecond = millisecond;
     }
-
+    
     /**
      *
      * @return Time in milliseconds

--- a/src/main/java/fr/noop/subtitle/vtt/VttParser.java
+++ b/src/main/java/fr/noop/subtitle/vtt/VttParser.java
@@ -53,11 +53,16 @@ public class VttParser implements SubtitleParser {
 
     @Override
     public VttObject parse(InputStream is) throws IOException, SubtitleParsingException {
-    	return parse(is, true);
+    	return parse(is, 0, true);
     }
     
     @Override
     public VttObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException {
+    	return parse(is, 0, true);
+    }
+    
+    @Override
+    public VttObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException {
         // Create srt object
         VttObject vttObject = new VttObject();
 
@@ -105,8 +110,8 @@ public class VttParser implements SubtitleParser {
                             "Timecode textLine is badly formated: %s", textLine));
                 }
 
-                cue.setStartTime(this.parseTimeCode(textLine.substring(0, 12)));
-                cue.setEndTime(this.parseTimeCode(textLine.substring(17)));
+                cue.setStartTime(this.parseTimeCode(textLine.substring(0, 12), subtitleOffset));
+                cue.setEndTime(this.parseTimeCode(textLine.substring(17), subtitleOffset));
                 cursorStatus = CursorStatus.CUE_TIMECODE;
                 continue;
             }
@@ -291,13 +296,13 @@ public class VttParser implements SubtitleParser {
         return cueLines;
     }
 
-    private SubtitleTimeCode parseTimeCode(String timeCodeString) throws SubtitleParsingException {
+    private SubtitleTimeCode parseTimeCode(String timeCodeString, int subtitleOffset) throws SubtitleParsingException {
         try {
             int hour = Integer.parseInt(timeCodeString.substring(0, 2));
             int minute = Integer.parseInt(timeCodeString.substring(3, 5));
             int second = Integer.parseInt(timeCodeString.substring(6, 8));
             int millisecond = Integer.parseInt(timeCodeString.substring(9, 12));
-            return new SubtitleTimeCode(hour, minute, second, millisecond);
+            return new SubtitleTimeCode(hour, minute, second, millisecond, subtitleOffset);
         } catch (NumberFormatException e) {
             throw new SubtitleParsingException(String.format(
                     "Unable to parse time code: %s", timeCodeString));

--- a/src/test/java/fr/noop/subtitle/util/SubtitleTimeCodeTest.java
+++ b/src/test/java/fr/noop/subtitle/util/SubtitleTimeCodeTest.java
@@ -21,6 +21,8 @@ import java.security.InvalidParameterException;
  */
 public class SubtitleTimeCodeTest  {
     private SubtitleTimeCode tested = new SubtitleTimeCode(1, 23, 12, 10);
+    private SubtitleTimeCode testedOffsetPositive = new SubtitleTimeCode(1, 23, 12, 10, 3775033);
+    private SubtitleTimeCode testedOffsetNegative = new SubtitleTimeCode(16, 23, 12, 10, -36000000);
 
     @Test
     public void testToString() throws Exception {
@@ -28,8 +30,28 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test
+    public void testOffsetPositiveToString() throws Exception {
+        assertEquals("02:26:07.043", testedOffsetPositive.toString());
+    }
+    
+    @Test
+    public void testOffsetNegativeToString() throws Exception {
+        assertEquals("06:23:12.010", testedOffsetNegative.toString());
+    }
+    
+    @Test
     public void testGetHour() throws Exception {
         assertEquals(1, tested.getHour());
+    }
+
+    @Test
+    public void testOffsetPositiveGetHour() throws Exception {
+        assertEquals(2, testedOffsetPositive.getHour());
+    }
+
+    @Test
+    public void testOffsetNegativeGetHour() throws Exception {
+        assertEquals(6, testedOffsetNegative.getHour());
     }
 
     @Test
@@ -38,9 +60,31 @@ public class SubtitleTimeCodeTest  {
         assertEquals(2, tested.getHour());
     }
 
+    @Test
+    public void testOffsetPositiveSetHour() throws Exception {
+        testedOffsetPositive.setHour(4);
+        assertEquals(4, testedOffsetPositive.getHour());
+    }
+
+    @Test
+    public void testOffsetNegativeSetHour() throws Exception {
+        testedOffsetNegative.setHour(12);
+        assertEquals(12, testedOffsetNegative.getHour());
+    }
+
     @Test (expected = InvalidParameterException.class)
     public void testSetHourException() throws Exception {
         tested.setHour(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetHourException() throws Exception {
+    	testedOffsetPositive.setHour(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetHourException() throws Exception {
+    	testedOffsetNegative.setHour(-1);
     }
 
     @Test
@@ -49,9 +93,31 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test
+    public void testOffsetPositiveGetMinute() throws Exception {
+        assertEquals(26, testedOffsetPositive.getMinute());
+    }
+
+    @Test
+    public void testOffsetNegativeGetMinute() throws Exception {
+        assertEquals(23, testedOffsetNegative.getMinute());
+    }
+
+    @Test
     public void testSetMinute() throws Exception {
         tested.setMinute(50);
         assertEquals(50, tested.getMinute());
+    }
+
+    @Test
+    public void testOffsetPositiveSetMinute() throws Exception {
+        testedOffsetPositive.setMinute(50);
+        assertEquals(50, testedOffsetPositive.getMinute());
+    }
+
+    @Test
+    public void testOffsetNegativeSetMinute() throws Exception {
+        testedOffsetNegative.setMinute(50);
+        assertEquals(50, testedOffsetNegative.getMinute());
     }
 
     @Test (expected = InvalidParameterException.class)
@@ -60,13 +126,40 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetMinuteException1() throws Exception {
+    	testedOffsetPositive.setMinute(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetMinuteException1() throws Exception {
+    	testedOffsetNegative.setMinute(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
     public void testSetMinuteException2() throws Exception {
         tested.setMinute(60);
     }
 
-    @Test
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetMinuteException2() throws Exception {
+    	testedOffsetPositive.setMinute(60);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetMinuteException2() throws Exception {
+    	testedOffsetNegative.setMinute(60);
+    }
+
     public void testGetSecond() throws Exception {
         assertEquals(12, tested.getSecond());
+    }
+
+    public void testOffsetPositiveGetSecond() throws Exception {
+        assertEquals(7, testedOffsetPositive.getSecond());
+    }
+
+    public void testOffsetNegativeGetSecond() throws Exception {
+        assertEquals(12, testedOffsetNegative.getSecond());
     }
 
     @Test
@@ -75,14 +168,46 @@ public class SubtitleTimeCodeTest  {
         assertEquals(50, tested.getSecond());
     }
 
+    @Test
+    public void testOffsetPositiveSetSecond() throws Exception {
+        testedOffsetPositive.setSecond(50);
+        assertEquals(50, testedOffsetPositive.getSecond());
+    }
+
+    @Test
+    public void testOffsetNegativeSetSecond() throws Exception {
+        testedOffsetNegative.setSecond(50);
+        assertEquals(50, testedOffsetNegative.getSecond());
+    }
+
     @Test (expected = InvalidParameterException.class)
     public void testSetSecondException1() throws Exception {
         tested.setSecond(-1);
     }
 
     @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetSecondException1() throws Exception {
+    	testedOffsetPositive.setSecond(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetSecondException1() throws Exception {
+    	testedOffsetNegative.setSecond(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
     public void testSetSecondException2() throws Exception {
         tested.setSecond(60);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetSecondException2() throws Exception {
+    	testedOffsetPositive.setSecond(60);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetSecondException2() throws Exception {
+    	testedOffsetNegative.setSecond(60);
     }
 
     @Test
@@ -91,9 +216,31 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test
+    public void testOffsetPositiveGetMillisecond() throws Exception {
+        assertEquals(43, testedOffsetPositive.getMillisecond());
+    }
+
+    @Test
+    public void testOffsetNegativeGetMillisecond() throws Exception {
+        assertEquals(10, testedOffsetNegative.getMillisecond());
+    }
+
+    @Test
     public void testSetMillisecond() throws Exception {
         tested.setMillisecond(50);
         assertEquals(50, tested.getMillisecond());
+    }
+
+    @Test
+    public void testOffsetPositiveSetMillisecond() throws Exception {
+        testedOffsetPositive.setMillisecond(50);
+        assertEquals(50, testedOffsetPositive.getMillisecond());
+    }
+
+    @Test
+    public void testOffsetNegativeSetMillisecond() throws Exception {
+    	testedOffsetNegative.setMillisecond(50);
+        assertEquals(50, testedOffsetNegative.getMillisecond());
     }
 
     @Test (expected = InvalidParameterException.class)
@@ -102,13 +249,43 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetMillisecondException1() throws Exception {
+    	testedOffsetPositive.setMillisecond(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetMillisecondException1() throws Exception {
+    	testedOffsetNegative.setMillisecond(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
     public void testSetMillisecondException2() throws Exception {
         tested.setMillisecond(1000);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetMillisecondException2() throws Exception {
+    	testedOffsetPositive.setMillisecond(1000);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetMillisecondException2() throws Exception {
+    	testedOffsetNegative.setMillisecond(1000);
     }
 
     @Test
     public void testGetTime() throws Exception {
         assertEquals(4992010, tested.getTime());
+    }
+
+    @Test
+    public void testOffsetPositiveGetTime() throws Exception {
+        assertEquals(8767043, testedOffsetPositive.getTime());
+    }
+
+    @Test
+    public void testOffsetNegativeGetTime() throws Exception {
+        assertEquals(22992010, testedOffsetNegative.getTime());
     }
 
     @Test
@@ -119,10 +296,44 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test
+    public void testOffsetPositiveCompareTo() throws Exception {
+        assertEquals(0, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 26, 7, 43)));
+        assertEquals(0, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 26, 7, 43, 0)));
+        assertEquals(0, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 26, 7, 33, 10)));
+        assertEquals(1, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 20, 7, 33, 10)));
+        assertEquals(-1, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 30, 7, 33, 10)));
+    }
+
+    @Test
+    public void testOffsetNegativeCompareTo() throws Exception {
+        assertEquals(0, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 23, 12, 10)));
+        assertEquals(0, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 23, 12, 10, 0)));
+        assertEquals(0, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 30, 12, 10, -420000)));
+        assertEquals(1, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 20, 12, 10, 0)));
+        assertEquals(-1, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 30, 12, 10, 0)));
+    }
+
+    @Test
     public void testSubtract() throws Exception {
         // Subtract 1 hour, 10 minutes, 3 seconds and 3 frames
         SubtitleTimeCode toSubtract = new SubtitleTimeCode(1, 10, 3, 3);
         SubtitleTimeCode expected = new SubtitleTimeCode(0, 13, 9, 7);
         assertEquals(expected.getTime(), tested.subtract(toSubtract).getTime());
+    }
+    
+    @Test
+    public void testOffsetPositiveSubtract() throws Exception {
+        // Subtract 1 hour, 10 minutes, 3 seconds and 3 frames
+        SubtitleTimeCode toSubtract = new SubtitleTimeCode(1, 10, 3, 0, 3);
+        SubtitleTimeCode expected = new SubtitleTimeCode(1, 16, 4, 40);
+        assertEquals(expected.getTime(), testedOffsetPositive.subtract(toSubtract).getTime());
+    }
+    
+    @Test
+    public void testOffsetNegativeSubtract() throws Exception {
+        // Subtract 1 hour, 10 minutes, 3 seconds and 3 frames ::6, 23, 12, 10
+        SubtitleTimeCode toSubtract = new SubtitleTimeCode(1, 10, 3, 0, 3);
+        SubtitleTimeCode expected = new SubtitleTimeCode(5, 13, 9, 7, 0);
+        assertEquals(expected.getTime(), testedOffsetNegative.subtract(toSubtract).getTime());
     }
 }


### PR DESCRIPTION
Ajout de l'option d’exécution -so permettant de gérer un offset en millisecondes pour les time code, positif ou negatif.
