### PR TITLE
Feature/experimental

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fr.noop</groupId>
     <artifactId>subtitle</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>subtitle</name>
     <description>

--- a/src/main/java/fr/noop/subtitle/Convert.java
+++ b/src/main/java/fr/noop/subtitle/Convert.java
@@ -194,6 +194,13 @@ public class Convert {
         HelpFormatter formatter = new HelpFormatter();
         formatter.printHelp("subtitle-convert", this.options);
     }
+    
+    public static void stream(InputStream is, String inputExtension, String inputCharset, boolean disableStrictMode, int offset, OutputStream os, String outputExtension, String outputCharset) throws IOException, SubtitleParsingException {
+	SubtitleParser parser = buildParser( "dummy." + inputExtension, inputCharset, offset );
+	SubtitleObject subtitle = parser.parse(is, offset, !disableStrictMode);
+	SubtitleWriter writer = buildWriter( "dummy." + outputExtension, outputCharset );
+	writer.write(subtitle, os);
+    }
 
     /**
      * Run convert command line
@@ -224,7 +231,7 @@ public class Convert {
             SubtitleParser subtitleParser = null;
 
             try {
-                subtitleParser = this.buildParser(inputFilePath, inputCharset, subtitleOffset);
+                subtitleParser = buildParser(inputFilePath, inputCharset, subtitleOffset);
             } catch(IOException e) {
                 System.out.println(String.format("Unable to build parser for file %s: %s", inputFilePath, e.getMessage()));
                 System.exit(1);
@@ -257,7 +264,7 @@ public class Convert {
             SubtitleWriter writer = null;
 
             try {
-                writer = this.buildWriter(outputFilePath, outputCharset);
+                writer = buildWriter(outputFilePath, outputCharset);
             } catch(IOException e) {
                 System.out.println(String.format("Unable to build writer for file %s: %s", outputFilePath, e.getMessage()));
                 System.exit(1);
@@ -287,8 +294,8 @@ public class Convert {
         }
     }
 
-    private SubtitleParser buildParser(String filePath, String charset, int offset) throws IOException {
-        String ext = this.getFileExtension(filePath);
+    public static SubtitleParser buildParser(String filePath, String charset, int offset) throws IOException {
+        String ext = getFileExtension(filePath);
 
         // Get subtitle parser class
         ConvertFormat convertFormat = ConvertFormat.getEnum(ext);
@@ -308,8 +315,8 @@ public class Convert {
         }
     }
 
-    private SubtitleWriter buildWriter(String filePath, String charset) throws IOException {
-        String ext = this.getFileExtension(filePath);
+    private static SubtitleWriter buildWriter(String filePath, String charset) throws IOException {
+        String ext = getFileExtension(filePath);
 
         // Get subtitle writer class
         ConvertFormat convertFormat = ConvertFormat.getEnum(ext);
@@ -328,8 +335,10 @@ public class Convert {
             throw new IOException(String.format("Unable to instantiate class %s", convertWriter.getClassName()));
         }
     }
+    
+    
 
-    private String getFileExtension(String filePath) throws IOException {
+    private static String getFileExtension(String filePath) throws IOException {
         String ext = null;
 
         int i = filePath.lastIndexOf('.');

--- a/src/main/java/fr/noop/subtitle/Convert.java
+++ b/src/main/java/fr/noop/subtitle/Convert.java
@@ -167,12 +167,19 @@ public class Convert {
                 .desc("Output charset")
                 .build());
         
-
         // Output charset option
         this.options.addOption(Option.builder("dsm")
                 .required(false)
                 .longOpt("disable-strict-mode")
                 .desc("Disable strict mode")
+                .build());
+
+        // Output charset option
+        this.options.addOption(Option.builder("so")
+                .required(false)
+                .longOpt("offset")
+                .hasArg()
+                .desc("Subtitles offset")
                 .build());
     }
 
@@ -211,12 +218,13 @@ public class Convert {
             String inputCharset = line.getOptionValue("ic", "utf-8");
             String outputCharset = line.getOptionValue("oc", "utf-8");
             boolean disableStrictMode = line.hasOption("disable-strict-mode");
+            int subtitleOffset = Integer.parseInt(line.getOptionValue("so", "0"));
 
             // Build parser for input file
             SubtitleParser subtitleParser = null;
 
             try {
-                subtitleParser = this.buildParser(inputFilePath, inputCharset);
+                subtitleParser = this.buildParser(inputFilePath, inputCharset, subtitleOffset);
             } catch(IOException e) {
                 System.out.println(String.format("Unable to build parser for file %s: %s", inputFilePath, e.getMessage()));
                 System.exit(1);
@@ -236,7 +244,7 @@ public class Convert {
             SubtitleObject inputSubtitle = null;
 
             try {
-                inputSubtitle = subtitleParser.parse(is, !disableStrictMode);
+                inputSubtitle = subtitleParser.parse(is, subtitleOffset, !disableStrictMode);
             } catch (IOException e) {
                 System.out.println(String.format("Unable ro read input file %s: %s", inputFilePath, e.getMessage()));
                 System.exit(1);
@@ -279,7 +287,7 @@ public class Convert {
         }
     }
 
-    private SubtitleParser buildParser(String filePath, String charset) throws IOException {
+    private SubtitleParser buildParser(String filePath, String charset, int offset) throws IOException {
         String ext = this.getFileExtension(filePath);
 
         // Get subtitle parser class

--- a/src/main/java/fr/noop/subtitle/Convert.java
+++ b/src/main/java/fr/noop/subtitle/Convert.java
@@ -195,9 +195,9 @@ public class Convert {
         formatter.printHelp("subtitle-convert", this.options);
     }
     
-    public static void stream(InputStream is, String inputExtension, String inputCharset, boolean disableStrictMode, int offset, OutputStream os, String outputExtension, String outputCharset) throws IOException, SubtitleParsingException {
-	SubtitleParser parser = buildParser( "dummy." + inputExtension, inputCharset, offset );
-	SubtitleObject subtitle = parser.parse(is, offset, !disableStrictMode);
+    public static void stream(InputStream is, String inputExtension, String inputCharset, boolean disableStrictMode, int offset, int duration, OutputStream os, String outputExtension, String outputCharset) throws IOException, SubtitleParsingException {
+	SubtitleParser parser = buildParser( "dummy." + inputExtension, inputCharset, offset, duration );
+	SubtitleObject subtitle = parser.parse(is, offset, duration, !disableStrictMode);
 	SubtitleWriter writer = buildWriter( "dummy." + outputExtension, outputCharset );
 	writer.write(subtitle, os);
     }
@@ -226,12 +226,13 @@ public class Convert {
             String outputCharset = line.getOptionValue("oc", "utf-8");
             boolean disableStrictMode = line.hasOption("disable-strict-mode");
             int subtitleOffset = Integer.parseInt(line.getOptionValue("so", "0"));
+            int maxDuration = Integer.parseInt(line.getOptionValue("sd", "-1"));
 
             // Build parser for input file
             SubtitleParser subtitleParser = null;
 
             try {
-                subtitleParser = buildParser(inputFilePath, inputCharset, subtitleOffset);
+                subtitleParser = buildParser(inputFilePath, inputCharset, subtitleOffset, maxDuration);
             } catch(IOException e) {
                 System.out.println(String.format("Unable to build parser for file %s: %s", inputFilePath, e.getMessage()));
                 System.exit(1);
@@ -251,7 +252,7 @@ public class Convert {
             SubtitleObject inputSubtitle = null;
 
             try {
-                inputSubtitle = subtitleParser.parse(is, subtitleOffset, !disableStrictMode);
+                inputSubtitle = subtitleParser.parse(is, subtitleOffset, maxDuration, !disableStrictMode);
             } catch (IOException e) {
                 System.out.println(String.format("Unable ro read input file %s: %s", inputFilePath, e.getMessage()));
                 System.exit(1);
@@ -294,7 +295,7 @@ public class Convert {
         }
     }
 
-    public static SubtitleParser buildParser(String filePath, String charset, int offset) throws IOException {
+    public static SubtitleParser buildParser(String filePath, String charset, int offset, int duration) throws IOException {
         String ext = getFileExtension(filePath);
 
         // Get subtitle parser class

--- a/src/main/java/fr/noop/subtitle/model/SubtitleParser.java
+++ b/src/main/java/fr/noop/subtitle/model/SubtitleParser.java
@@ -19,4 +19,5 @@ import java.io.InputStream;
 public interface SubtitleParser {
     public SubtitleObject parse(InputStream is) throws IOException, SubtitleParsingException;
     public SubtitleObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException;
+    public SubtitleObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException;
 }

--- a/src/main/java/fr/noop/subtitle/model/SubtitleParser.java
+++ b/src/main/java/fr/noop/subtitle/model/SubtitleParser.java
@@ -20,4 +20,5 @@ public interface SubtitleParser {
     public SubtitleObject parse(InputStream is) throws IOException, SubtitleParsingException;
     public SubtitleObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException;
     public SubtitleObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException;
+    public SubtitleObject parse(InputStream is, int subtitleOffset, int maxDuration, boolean strict) throws IOException, SubtitleParsingException;
 }

--- a/src/main/java/fr/noop/subtitle/model/SubtitleWriter.java
+++ b/src/main/java/fr/noop/subtitle/model/SubtitleWriter.java
@@ -10,8 +10,6 @@
 
 package fr.noop.subtitle.model;
 
-import fr.noop.subtitle.base.BaseSubtitleObject;
-
 import java.io.IOException;
 import java.io.OutputStream;
 

--- a/src/main/java/fr/noop/subtitle/sami/SamiParser.java
+++ b/src/main/java/fr/noop/subtitle/sami/SamiParser.java
@@ -42,11 +42,16 @@ public class SamiParser implements SubtitleParser {
 
     @Override
     public SamiObject parse(InputStream is) throws IOException, SubtitleParsingException {
-    	return parse(is, true);
+    	return parse(is, 0, true);
     }
     
     @Override
     public SamiObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException {
+    	return this.parse(is, 0, strict);
+    }
+    
+    @Override
+    public SamiObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException {
         // Create SAMI object
         SamiObject samiObject = new SamiObject();
 
@@ -103,7 +108,7 @@ public class SamiParser implements SubtitleParser {
                 long time;
 
                 try {
-                    time = Long.valueOf(startTime);
+                    time = Long.valueOf(startTime + subtitleOffset);
                 } catch (NumberFormatException e) {
                     throw new SubtitleParsingException(String.format(
                             "Unable to parse start time: %s",
@@ -155,7 +160,7 @@ public class SamiParser implements SubtitleParser {
         // Set end time for the last cue
         if (previousCue != null) {
             // Last cue duration is 2s
-            previousCue.setEndTime(new SubtitleTimeCode(previousCue.getStartTime().getTime() + 2000));
+            previousCue.setEndTime(new SubtitleTimeCode(previousCue.getStartTime().getTime() + 2000 + subtitleOffset));
         }
 
         return samiObject;

--- a/src/main/java/fr/noop/subtitle/sami/SamiParser.java
+++ b/src/main/java/fr/noop/subtitle/sami/SamiParser.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import fr.noop.subtitle.model.SubtitleObject;
 import fr.noop.subtitle.model.SubtitleParser;
 import fr.noop.subtitle.model.SubtitleParsingException;
 import fr.noop.subtitle.util.SubtitlePlainText;
@@ -165,4 +166,11 @@ public class SamiParser implements SubtitleParser {
 
         return samiObject;
     }
+    
+
+    @Override
+    public SubtitleObject parse(InputStream is, int subtitleOffset, int maxDuration, boolean strict)
+	    throws IOException, SubtitleParsingException {
+	throw new SubtitleParsingException("Not implemented");
+    }    
 }

--- a/src/main/java/fr/noop/subtitle/srt/SrtParser.java
+++ b/src/main/java/fr/noop/subtitle/srt/SrtParser.java
@@ -40,11 +40,16 @@ public class SrtParser implements SubtitleParser {
 
     @Override
     public SrtObject parse(InputStream is) throws IOException, SubtitleParsingException {
-    	return parse(is, true);
+    	return parse(is, 0, true);
     }
     
     @Override
     public SrtObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException {
+    	return this.parse(is, 0, strict);
+    }
+    
+    @Override
+    public SrtObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException {
         // Create srt object
         SrtObject srtObject = new SrtObject();
 
@@ -87,8 +92,8 @@ public class SrtParser implements SubtitleParser {
                             "Timecode textLine is badly formated: %s", textLine));
                 }
 
-                cue.setStartTime(this.parseTimeCode(textLine.substring(0, 12)));
-                cue.setEndTime(this.parseTimeCode(textLine.substring(17)));
+                cue.setStartTime(this.parseTimeCode(textLine.substring(0, 12), subtitleOffset));
+                cue.setEndTime(this.parseTimeCode(textLine.substring(17), subtitleOffset));
                 cursorStatus = CursorStatus.CUE_TIMECODE;
                 continue;
             }
@@ -123,13 +128,13 @@ public class SrtParser implements SubtitleParser {
         return srtObject;
     }
 
-    private SubtitleTimeCode parseTimeCode(String timeCodeString) throws SubtitleParsingException {
+    private SubtitleTimeCode parseTimeCode(String timeCodeString, int subtitleOffset) throws SubtitleParsingException {
         try {
             int hour = Integer.parseInt(timeCodeString.substring(0, 2));
             int minute = Integer.parseInt(timeCodeString.substring(3, 5));
             int second = Integer.parseInt(timeCodeString.substring(6, 8));
             int millisecond = Integer.parseInt(timeCodeString.substring(9, 12));
-            return new SubtitleTimeCode(hour, minute, second, millisecond);
+            return new SubtitleTimeCode(hour, minute, second, millisecond, subtitleOffset);
         } catch (NumberFormatException e) {
             throw new SubtitleParsingException(String.format(
                     "Unable to parse time code: %s", timeCodeString));

--- a/src/main/java/fr/noop/subtitle/srt/SrtParser.java
+++ b/src/main/java/fr/noop/subtitle/srt/SrtParser.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import fr.noop.subtitle.model.SubtitleObject;
 import fr.noop.subtitle.model.SubtitleParser;
 import fr.noop.subtitle.model.SubtitleParsingException;
 import fr.noop.subtitle.util.SubtitlePlainText;
@@ -139,5 +140,11 @@ public class SrtParser implements SubtitleParser {
             throw new SubtitleParsingException(String.format(
                     "Unable to parse time code: %s", timeCodeString));
         }
+    }
+
+    @Override
+    public SubtitleObject parse(InputStream is, int subtitleOffset, int maxDuration, boolean strict)
+	    throws IOException, SubtitleParsingException {
+	throw new SubtitleParsingException("Not implemented");
     }
 }

--- a/src/main/java/fr/noop/subtitle/stl/StlParser.java
+++ b/src/main/java/fr/noop/subtitle/stl/StlParser.java
@@ -21,6 +21,7 @@ import java.util.Date;
 
 import org.apache.commons.lang3.StringUtils;
 
+import fr.noop.subtitle.model.SubtitleObject;
 import fr.noop.subtitle.model.SubtitleParser;
 import fr.noop.subtitle.model.SubtitleParsingException;
 import fr.noop.subtitle.util.SubtitleTimeCode;
@@ -277,5 +278,11 @@ public class StlParser implements SubtitleParser {
 
         // TTI is fully parsed
         return tti;
+    }
+
+    @Override
+    public SubtitleObject parse(InputStream is, int subtitleOffset, int maxDuration, boolean strict)
+	    throws IOException, SubtitleParsingException {
+	throw new SubtitleParsingException("Not implemented");
     }
 }

--- a/src/main/java/fr/noop/subtitle/util/SubtitleTimeCode.java
+++ b/src/main/java/fr/noop/subtitle/util/SubtitleTimeCode.java
@@ -17,6 +17,7 @@ import java.time.LocalTime;
  * Created by clebeaupin on 22/09/15.
  */
 public class SubtitleTimeCode implements Comparable<SubtitleTimeCode> {
+	private final int MAX_HOUR = 24;
     private final int MS_HOUR = 3600000;
     private final int MS_MINUTE = 60000;
     private final int MS_SECOND = 1000;
@@ -25,15 +26,28 @@ public class SubtitleTimeCode implements Comparable<SubtitleTimeCode> {
     private int second;
     private int millisecond;
 
+    public SubtitleTimeCode(int hour, int minute, int second, int millisecond, int offset) {
+    	int newTime = hour*MS_HOUR+minute*MS_MINUTE+second*MS_SECOND+millisecond + offset;
+        
+        int newHour = (int) ((newTime/MS_HOUR)%MAX_HOUR);
+        int minuteOffsetRest = newTime%MS_HOUR;
+    	int newMinute = (int) (minuteOffsetRest/MS_MINUTE);
+    	int secondOffsetRest = minuteOffsetRest%MS_MINUTE;
+    	int newSecond = (int) (secondOffsetRest/MS_SECOND);
+    	int newMillisecond = secondOffsetRest%MS_SECOND;  
+    	
+    	this.setHour(newHour);
+        this.setMinute(newMinute);
+        this.setSecond(newSecond);
+        this.setMillisecond(newMillisecond);
+    }
+
     public SubtitleTimeCode(int hour, int minute, int second, int millisecond) {
-        this.setHour(hour);
-        this.setMinute(minute);
-        this.setSecond(second);
-        this.setMillisecond(millisecond);
+    	this(hour, minute, second, millisecond, 0);
     }
 
     public SubtitleTimeCode(LocalTime time) {
-        this(time.getHour(), time.getMinute(), time.getSecond(), 0);
+        this(time.getHour(), time.getMinute(), time.getSecond(), 0, 0);
     }
 
     /**
@@ -99,7 +113,7 @@ public class SubtitleTimeCode implements Comparable<SubtitleTimeCode> {
 
         this.millisecond = millisecond;
     }
-
+    
     /**
      *
      * @return Time in milliseconds

--- a/src/main/java/fr/noop/subtitle/util/SubtitleTimeCode.java
+++ b/src/main/java/fr/noop/subtitle/util/SubtitleTimeCode.java
@@ -28,7 +28,9 @@ public class SubtitleTimeCode implements Comparable<SubtitleTimeCode> {
 
     public SubtitleTimeCode(int hour, int minute, int second, int millisecond, int offset) {
     	int newTime = hour*MS_HOUR+minute*MS_MINUTE+second*MS_SECOND+millisecond + offset;
-        
+        if (newTime < 0) {
+            throw new InvalidParameterException("Cannot create a timecode before time zero (check your offset) !");
+        }
         int newHour = (int) ((newTime/MS_HOUR)%MAX_HOUR);
         int minuteOffsetRest = newTime%MS_HOUR;
     	int newMinute = (int) (minuteOffsetRest/MS_MINUTE);

--- a/src/main/java/fr/noop/subtitle/vtt/VttParser.java
+++ b/src/main/java/fr/noop/subtitle/vtt/VttParser.java
@@ -53,11 +53,16 @@ public class VttParser implements SubtitleParser {
 
     @Override
     public VttObject parse(InputStream is) throws IOException, SubtitleParsingException {
-    	return parse(is, true);
+    	return parse(is, 0, true);
     }
     
     @Override
     public VttObject parse(InputStream is, boolean strict) throws IOException, SubtitleParsingException {
+    	return parse(is, 0, true);
+    }
+    
+    @Override
+    public VttObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException {
         // Create srt object
         VttObject vttObject = new VttObject();
 
@@ -105,8 +110,8 @@ public class VttParser implements SubtitleParser {
                             "Timecode textLine is badly formated: %s", textLine));
                 }
 
-                cue.setStartTime(this.parseTimeCode(textLine.substring(0, 12)));
-                cue.setEndTime(this.parseTimeCode(textLine.substring(17)));
+                cue.setStartTime(this.parseTimeCode(textLine.substring(0, 12), subtitleOffset));
+                cue.setEndTime(this.parseTimeCode(textLine.substring(17), subtitleOffset));
                 cursorStatus = CursorStatus.CUE_TIMECODE;
                 continue;
             }
@@ -291,13 +296,13 @@ public class VttParser implements SubtitleParser {
         return cueLines;
     }
 
-    private SubtitleTimeCode parseTimeCode(String timeCodeString) throws SubtitleParsingException {
+    private SubtitleTimeCode parseTimeCode(String timeCodeString, int subtitleOffset) throws SubtitleParsingException {
         try {
             int hour = Integer.parseInt(timeCodeString.substring(0, 2));
             int minute = Integer.parseInt(timeCodeString.substring(3, 5));
             int second = Integer.parseInt(timeCodeString.substring(6, 8));
             int millisecond = Integer.parseInt(timeCodeString.substring(9, 12));
-            return new SubtitleTimeCode(hour, minute, second, millisecond);
+            return new SubtitleTimeCode(hour, minute, second, millisecond, subtitleOffset);
         } catch (NumberFormatException e) {
             throw new SubtitleParsingException(String.format(
                     "Unable to parse time code: %s", timeCodeString));

--- a/src/main/java/fr/noop/subtitle/vtt/VttParser.java
+++ b/src/main/java/fr/noop/subtitle/vtt/VttParser.java
@@ -66,6 +66,11 @@ public class VttParser implements SubtitleParser {
     
     @Override
     public VttObject parse(InputStream is, int subtitleOffset, boolean strict) throws IOException, SubtitleParsingException {
+	return parse(is, subtitleOffset, -1, strict);
+    }
+    
+    @Override
+    public VttObject parse(InputStream is, int subtitleOffset, int maxDuration, boolean strict) throws IOException, SubtitleParsingException {
         // Create srt object
         VttObject vttObject = new VttObject();
 
@@ -118,6 +123,9 @@ public class VttParser implements SubtitleParser {
                 try {
                     cue.setStartTime(this.parseTimeCode(textLine.substring(0, arrowStart-1), subtitleOffset));
                     cue.setEndTime(this.parseTimeCode(textLine.substring(arrowStart + 4), subtitleOffset));
+                    if (cue.getStartTime().getTime() > maxDuration - subtitleOffset || cue.getEndTime().getTime() > maxDuration - subtitleOffset) {
+                	shouldIgnoreCurrentCue = true;
+                    }
                 } catch (InvalidParameterException e) {
                     shouldIgnoreCurrentCue = true;
                 }
@@ -345,4 +353,5 @@ public class VttParser implements SubtitleParser {
                     "Unable to parse time code: %s", timeCodeString));
         }
     }
+
 }

--- a/src/main/java/fr/noop/subtitle/vtt/VttParser.java
+++ b/src/main/java/fr/noop/subtitle/vtt/VttParser.java
@@ -14,8 +14,11 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 
 import fr.noop.subtitle.model.SubtitleLine;
 import fr.noop.subtitle.model.SubtitleParser;
@@ -71,6 +74,7 @@ public class VttParser implements SubtitleParser {
         String textLine = "";
         CursorStatus cursorStatus = CursorStatus.NONE;
         VttCue cue = null;
+        boolean shouldIgnoreCurrentCue = false;
         String cueText = ""; // Text of the cue
 
         while ((textLine = br.readLine()) != null) {
@@ -90,9 +94,10 @@ public class VttParser implements SubtitleParser {
 
                 // New cue
                 cue = new VttCue();
+                shouldIgnoreCurrentCue = false;
                 cursorStatus = CursorStatus.CUE_ID;
-
-                if (!textLine.substring(13, 16).equals("-->")) {
+                int arrowStart = textLine.indexOf("-->");
+                if (arrowStart == -1) {
                     // First textLine is the cue number
                     cue.setId(textLine);
                     continue;
@@ -105,13 +110,17 @@ public class VttParser implements SubtitleParser {
             // Second textLine defines the start and end time codes
             // 00:01:21.456 --> 00:01:23.417
             if (cursorStatus == CursorStatus.CUE_ID) {
-                if (!textLine.substring(13, 16).equals("-->")) {
+        	int arrowStart = textLine.indexOf("-->");
+                if (arrowStart == -1) {
                     throw new SubtitleParsingException(String.format(
                             "Timecode textLine is badly formated: %s", textLine));
                 }
-
-                cue.setStartTime(this.parseTimeCode(textLine.substring(0, 12), subtitleOffset));
-                cue.setEndTime(this.parseTimeCode(textLine.substring(17), subtitleOffset));
+                try {
+                    cue.setStartTime(this.parseTimeCode(textLine.substring(0, arrowStart-1), subtitleOffset));
+                    cue.setEndTime(this.parseTimeCode(textLine.substring(arrowStart + 4), subtitleOffset));
+                } catch (InvalidParameterException e) {
+                    shouldIgnoreCurrentCue = true;
+                }
                 cursorStatus = CursorStatus.CUE_TIMECODE;
                 continue;
             }
@@ -131,7 +140,11 @@ public class VttParser implements SubtitleParser {
                 if (textLine.isEmpty()) {
 					if (!strict) {
 						cue.setLines(parseCueText(cueText));
-						vttObject.addCue(cue);
+						if (!shouldIgnoreCurrentCue) {
+						    vttObject.addCue(cue);
+						} else {
+						    shouldIgnoreCurrentCue = false;
+						}
 						cue = null;
 						cueText = "";
 						cursorStatus = CursorStatus.EMPTY_LINE;
@@ -148,7 +161,11 @@ public class VttParser implements SubtitleParser {
                 // Process multilines text in one time
                 // A class or a style can be applied for more than one line
                 cue.setLines(parseCueText(cueText));
-                vttObject.addCue(cue);
+                if (!shouldIgnoreCurrentCue) {
+                    vttObject.addCue(cue);
+                } else {
+		    shouldIgnoreCurrentCue = false;
+		}
                 cue = null;
                 cueText = "";
                 cursorStatus = CursorStatus.EMPTY_LINE;
@@ -296,13 +313,33 @@ public class VttParser implements SubtitleParser {
         return cueLines;
     }
 
-    private SubtitleTimeCode parseTimeCode(String timeCodeString, int subtitleOffset) throws SubtitleParsingException {
+    protected SubtitleTimeCode parseTimeCode(String timeCodeString, int subtitleOffset) throws SubtitleParsingException {
         try {
-            int hour = Integer.parseInt(timeCodeString.substring(0, 2));
-            int minute = Integer.parseInt(timeCodeString.substring(3, 5));
-            int second = Integer.parseInt(timeCodeString.substring(6, 8));
-            int millisecond = Integer.parseInt(timeCodeString.substring(9, 12));
-            return new SubtitleTimeCode(hour, minute, second, millisecond, subtitleOffset);
+            int separatorCount = StringUtils.countMatches(timeCodeString, ":");
+            if (separatorCount > 1) {
+        	// hh:mm:ss.ms
+        	int offset = timeCodeString.indexOf(":");
+        	int hour = Integer.parseInt(timeCodeString.substring(0, offset));
+        	String buffer = timeCodeString.substring(offset+1);
+        	offset = buffer.indexOf(":");
+        	int minute = Integer.parseInt(buffer.substring(0, offset));
+        	buffer = buffer.substring(offset+1);
+        	offset = buffer.indexOf(".");
+        	int second = Integer.parseInt(buffer.substring(0, offset));
+        	buffer = buffer.substring(offset+1);
+        	int millisecond = Integer.parseInt(buffer);
+        	return new SubtitleTimeCode(hour, minute, second, millisecond, subtitleOffset);
+            } else {
+        	// mm:ss.ms
+        	int offset = timeCodeString.indexOf(":");
+        	int minute = Integer.parseInt(timeCodeString.substring(0, offset));
+        	String buffer = timeCodeString.substring(offset+1);
+        	offset = buffer.indexOf(".");
+        	int second = Integer.parseInt(buffer.substring(0, offset));
+        	buffer = buffer.substring(offset+1);
+        	int millisecond = Integer.parseInt(buffer);
+        	return new SubtitleTimeCode(0, minute, second, millisecond, subtitleOffset);
+            }
         } catch (NumberFormatException e) {
             throw new SubtitleParsingException(String.format(
                     "Unable to parse time code: %s", timeCodeString));

--- a/src/test/java/fr/noop/subtitle/util/SubtitleTimeCodeTest.java
+++ b/src/test/java/fr/noop/subtitle/util/SubtitleTimeCodeTest.java
@@ -21,6 +21,8 @@ import java.security.InvalidParameterException;
  */
 public class SubtitleTimeCodeTest  {
     private SubtitleTimeCode tested = new SubtitleTimeCode(1, 23, 12, 10);
+    private SubtitleTimeCode testedOffsetPositive = new SubtitleTimeCode(1, 23, 12, 10, 3775033);
+    private SubtitleTimeCode testedOffsetNegative = new SubtitleTimeCode(16, 23, 12, 10, -36000000);
 
     @Test
     public void testToString() throws Exception {
@@ -28,8 +30,28 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test
+    public void testOffsetPositiveToString() throws Exception {
+        assertEquals("02:26:07.043", testedOffsetPositive.toString());
+    }
+    
+    @Test
+    public void testOffsetNegativeToString() throws Exception {
+        assertEquals("06:23:12.010", testedOffsetNegative.toString());
+    }
+    
+    @Test
     public void testGetHour() throws Exception {
         assertEquals(1, tested.getHour());
+    }
+
+    @Test
+    public void testOffsetPositiveGetHour() throws Exception {
+        assertEquals(2, testedOffsetPositive.getHour());
+    }
+
+    @Test
+    public void testOffsetNegativeGetHour() throws Exception {
+        assertEquals(6, testedOffsetNegative.getHour());
     }
 
     @Test
@@ -38,9 +60,31 @@ public class SubtitleTimeCodeTest  {
         assertEquals(2, tested.getHour());
     }
 
+    @Test
+    public void testOffsetPositiveSetHour() throws Exception {
+        testedOffsetPositive.setHour(4);
+        assertEquals(4, testedOffsetPositive.getHour());
+    }
+
+    @Test
+    public void testOffsetNegativeSetHour() throws Exception {
+        testedOffsetNegative.setHour(12);
+        assertEquals(12, testedOffsetNegative.getHour());
+    }
+
     @Test (expected = InvalidParameterException.class)
     public void testSetHourException() throws Exception {
         tested.setHour(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetHourException() throws Exception {
+    	testedOffsetPositive.setHour(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetHourException() throws Exception {
+    	testedOffsetNegative.setHour(-1);
     }
 
     @Test
@@ -49,9 +93,31 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test
+    public void testOffsetPositiveGetMinute() throws Exception {
+        assertEquals(26, testedOffsetPositive.getMinute());
+    }
+
+    @Test
+    public void testOffsetNegativeGetMinute() throws Exception {
+        assertEquals(23, testedOffsetNegative.getMinute());
+    }
+
+    @Test
     public void testSetMinute() throws Exception {
         tested.setMinute(50);
         assertEquals(50, tested.getMinute());
+    }
+
+    @Test
+    public void testOffsetPositiveSetMinute() throws Exception {
+        testedOffsetPositive.setMinute(50);
+        assertEquals(50, testedOffsetPositive.getMinute());
+    }
+
+    @Test
+    public void testOffsetNegativeSetMinute() throws Exception {
+        testedOffsetNegative.setMinute(50);
+        assertEquals(50, testedOffsetNegative.getMinute());
     }
 
     @Test (expected = InvalidParameterException.class)
@@ -60,13 +126,40 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetMinuteException1() throws Exception {
+    	testedOffsetPositive.setMinute(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetMinuteException1() throws Exception {
+    	testedOffsetNegative.setMinute(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
     public void testSetMinuteException2() throws Exception {
         tested.setMinute(60);
     }
 
-    @Test
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetMinuteException2() throws Exception {
+    	testedOffsetPositive.setMinute(60);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetMinuteException2() throws Exception {
+    	testedOffsetNegative.setMinute(60);
+    }
+
     public void testGetSecond() throws Exception {
         assertEquals(12, tested.getSecond());
+    }
+
+    public void testOffsetPositiveGetSecond() throws Exception {
+        assertEquals(7, testedOffsetPositive.getSecond());
+    }
+
+    public void testOffsetNegativeGetSecond() throws Exception {
+        assertEquals(12, testedOffsetNegative.getSecond());
     }
 
     @Test
@@ -75,14 +168,46 @@ public class SubtitleTimeCodeTest  {
         assertEquals(50, tested.getSecond());
     }
 
+    @Test
+    public void testOffsetPositiveSetSecond() throws Exception {
+        testedOffsetPositive.setSecond(50);
+        assertEquals(50, testedOffsetPositive.getSecond());
+    }
+
+    @Test
+    public void testOffsetNegativeSetSecond() throws Exception {
+        testedOffsetNegative.setSecond(50);
+        assertEquals(50, testedOffsetNegative.getSecond());
+    }
+
     @Test (expected = InvalidParameterException.class)
     public void testSetSecondException1() throws Exception {
         tested.setSecond(-1);
     }
 
     @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetSecondException1() throws Exception {
+    	testedOffsetPositive.setSecond(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetSecondException1() throws Exception {
+    	testedOffsetNegative.setSecond(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
     public void testSetSecondException2() throws Exception {
         tested.setSecond(60);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetSecondException2() throws Exception {
+    	testedOffsetPositive.setSecond(60);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetSecondException2() throws Exception {
+    	testedOffsetNegative.setSecond(60);
     }
 
     @Test
@@ -91,9 +216,31 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test
+    public void testOffsetPositiveGetMillisecond() throws Exception {
+        assertEquals(43, testedOffsetPositive.getMillisecond());
+    }
+
+    @Test
+    public void testOffsetNegativeGetMillisecond() throws Exception {
+        assertEquals(10, testedOffsetNegative.getMillisecond());
+    }
+
+    @Test
     public void testSetMillisecond() throws Exception {
         tested.setMillisecond(50);
         assertEquals(50, tested.getMillisecond());
+    }
+
+    @Test
+    public void testOffsetPositiveSetMillisecond() throws Exception {
+        testedOffsetPositive.setMillisecond(50);
+        assertEquals(50, testedOffsetPositive.getMillisecond());
+    }
+
+    @Test
+    public void testOffsetNegativeSetMillisecond() throws Exception {
+    	testedOffsetNegative.setMillisecond(50);
+        assertEquals(50, testedOffsetNegative.getMillisecond());
     }
 
     @Test (expected = InvalidParameterException.class)
@@ -102,13 +249,43 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetMillisecondException1() throws Exception {
+    	testedOffsetPositive.setMillisecond(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetMillisecondException1() throws Exception {
+    	testedOffsetNegative.setMillisecond(-1);
+    }
+
+    @Test (expected = InvalidParameterException.class)
     public void testSetMillisecondException2() throws Exception {
         tested.setMillisecond(1000);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetPositiveSetMillisecondException2() throws Exception {
+    	testedOffsetPositive.setMillisecond(1000);
+    }
+
+    @Test (expected = InvalidParameterException.class)
+    public void testOffsetNegativeSetMillisecondException2() throws Exception {
+    	testedOffsetNegative.setMillisecond(1000);
     }
 
     @Test
     public void testGetTime() throws Exception {
         assertEquals(4992010, tested.getTime());
+    }
+
+    @Test
+    public void testOffsetPositiveGetTime() throws Exception {
+        assertEquals(8767043, testedOffsetPositive.getTime());
+    }
+
+    @Test
+    public void testOffsetNegativeGetTime() throws Exception {
+        assertEquals(22992010, testedOffsetNegative.getTime());
     }
 
     @Test
@@ -119,10 +296,44 @@ public class SubtitleTimeCodeTest  {
     }
 
     @Test
+    public void testOffsetPositiveCompareTo() throws Exception {
+        assertEquals(0, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 26, 7, 43)));
+        assertEquals(0, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 26, 7, 43, 0)));
+        assertEquals(0, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 26, 7, 33, 10)));
+        assertEquals(1, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 20, 7, 33, 10)));
+        assertEquals(-1, testedOffsetPositive.compareTo(new SubtitleTimeCode(2, 30, 7, 33, 10)));
+    }
+
+    @Test
+    public void testOffsetNegativeCompareTo() throws Exception {
+        assertEquals(0, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 23, 12, 10)));
+        assertEquals(0, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 23, 12, 10, 0)));
+        assertEquals(0, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 30, 12, 10, -420000)));
+        assertEquals(1, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 20, 12, 10, 0)));
+        assertEquals(-1, testedOffsetNegative.compareTo(new SubtitleTimeCode(6, 30, 12, 10, 0)));
+    }
+
+    @Test
     public void testSubtract() throws Exception {
         // Subtract 1 hour, 10 minutes, 3 seconds and 3 frames
         SubtitleTimeCode toSubtract = new SubtitleTimeCode(1, 10, 3, 3);
         SubtitleTimeCode expected = new SubtitleTimeCode(0, 13, 9, 7);
         assertEquals(expected.getTime(), tested.subtract(toSubtract).getTime());
+    }
+    
+    @Test
+    public void testOffsetPositiveSubtract() throws Exception {
+        // Subtract 1 hour, 10 minutes, 3 seconds and 3 frames
+        SubtitleTimeCode toSubtract = new SubtitleTimeCode(1, 10, 3, 0, 3);
+        SubtitleTimeCode expected = new SubtitleTimeCode(1, 16, 4, 40);
+        assertEquals(expected.getTime(), testedOffsetPositive.subtract(toSubtract).getTime());
+    }
+    
+    @Test
+    public void testOffsetNegativeSubtract() throws Exception {
+        // Subtract 1 hour, 10 minutes, 3 seconds and 3 frames ::6, 23, 12, 10
+        SubtitleTimeCode toSubtract = new SubtitleTimeCode(1, 10, 3, 0, 3);
+        SubtitleTimeCode expected = new SubtitleTimeCode(5, 13, 9, 7, 0);
+        assertEquals(expected.getTime(), testedOffsetNegative.subtract(toSubtract).getTime());
     }
 }

--- a/src/test/java/fr/noop/subtitle/vtt/VttParserTest.java
+++ b/src/test/java/fr/noop/subtitle/vtt/VttParserTest.java
@@ -1,0 +1,63 @@
+/*
+ *  This file is part of the noOp organization .
+ *
+ *  (c) Cyrille Lebeaupin <clebeaupin@noop.fr>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ */
+
+package fr.noop.subtitle.vtt;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import fr.noop.subtitle.model.SubtitleParsingException;
+import fr.noop.subtitle.util.SubtitleTimeCode;
+
+public class VttParserTest {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @Test
+    public void testFormatTimecode() throws SubtitleParsingException {
+	VttParser parser = new VttParser("UTF-8");
+	
+	SubtitleTimeCode tc = parser.parseTimeCode("00:10.000", 0);
+	assertEquals(0, tc.getHour());
+	assertEquals(0, tc.getMinute());
+	assertEquals(10, tc.getSecond());
+	assertEquals(0, tc.getMillisecond());
+	
+	tc = parser.parseTimeCode("00:13.000", 0);
+	assertEquals(0, tc.getHour());
+	assertEquals(0, tc.getMinute());
+	assertEquals(13, tc.getSecond());
+	assertEquals(0, tc.getMillisecond());
+	
+	tc = parser.parseTimeCode("02:13.880", 0);
+	assertEquals(0, tc.getHour());
+	assertEquals(2, tc.getMinute());
+	assertEquals(13, tc.getSecond());
+	assertEquals(880, tc.getMillisecond());
+	
+	tc = parser.parseTimeCode("1:27:10.200", 0);
+	assertEquals(1, tc.getHour());
+	assertEquals(27, tc.getMinute());
+	assertEquals(10, tc.getSecond());
+	assertEquals(200, tc.getMillisecond());
+	
+	tc = parser.parseTimeCode("02:27:10.200", 0);
+	assertEquals(2, tc.getHour());
+	assertEquals(27, tc.getMinute());
+	assertEquals(10, tc.getSecond());
+	assertEquals(200, tc.getMillisecond());
+	
+    }
+    
+}


### PR DESCRIPTION
From MarieTenegal's fork (that added offset support).
- Added support for all VTT timecode formats (mm:ss.ms and h:mm:ss.ms)
- Improved offset support for VTT to ignore subtitles when offset is negative
- Added stream support to the convert API (to be able to use the API outside a CLI in plain Java)
- Added a `maxDuration` parameter to implement a "trim subtitle" feature (only supported with VTT for now since it was our need)
