### PR TITLE
Add a bit of grace to StlParser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+*.iml
+
+target

--- a/src/main/java/fr/noop/subtitle/stl/StlParser.java
+++ b/src/main/java/fr/noop/subtitle/stl/StlParser.java
@@ -14,6 +14,7 @@ import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.CoderMalfunctionError;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -266,7 +267,13 @@ public class StlParser implements SubtitleParser {
         // Read TextField (TF)
         byte [] tfBytes = new byte[112];
         dis.readFully(tfBytes, 0, 112);
-        tti.setTf(new String(tfBytes, charset));
+        try {
+            tti.setTf(new String(tfBytes, charset));
+        } catch (CoderMalfunctionError e) {
+            // There exist some STL files in the wild, which contain userdata not parsable using the gsi charset
+            // this is the case for some kinds of software, which carry meta information in EBN-254 text fields
+            tti.setTf(new String(tfBytes));
+        }
 
         // TTI is fully parsed
         return tti;

--- a/src/main/java/fr/noop/subtitle/stl/StlParser.java
+++ b/src/main/java/fr/noop/subtitle/stl/StlParser.java
@@ -34,10 +34,14 @@ public class StlParser implements SubtitleParser {
     }
     
     public StlObject parse(InputStream is) throws SubtitleParsingException {
-    	return parse(is, true);
+    	return parse(is, true, false);
     }
 
     public StlObject parse(InputStream is, boolean strict) throws SubtitleParsingException {
+        return parse(is, strict, false);
+    }
+
+    public StlObject parse(InputStream is, boolean strict, boolean skipUserdataTf) throws SubtitleParsingException {
         BufferedInputStream bis = new BufferedInputStream(is);
         DataInputStream dis = new DataInputStream(bis);
 
@@ -64,7 +68,9 @@ public class StlParser implements SubtitleParser {
                 throw new SubtitleParsingException("Unable to parse tti block");
             }
 
-            stl.addTti(tti);
+            if (!skipUserdataTf || tti.getEbn() != 254) {
+                stl.addTti(tti);
+            }
         }
 
         return stl;


### PR DESCRIPTION
There exist some STL files in the wild, which contain userdata not parsable using the charset from `GSI`. This is the case for some kinds of software, which carry meta information in EBN-254 text fields. This is intended to make the `StlParser` usable, even if producers of subtitles incorrectly implement the EBU STL standard.

**StlParser: Gracefully parse text field (TF)**

Fall back to default charset in case of `CoderMalfunctionError` when reading the `TF` String.

**StlParser: flag to ignore Userdata**

Ignore EBN 254 Userdata if flag is set to true

**Also added .gitignore**