### PR TITLE
Make STL parsing more tolerant and configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+*.iml
+
+target

--- a/src/main/java/fr/noop/subtitle/stl/StlObject.java
+++ b/src/main/java/fr/noop/subtitle/stl/StlObject.java
@@ -45,7 +45,7 @@ public class StlObject extends BaseSubtitleObject {
         this.ttis = ttis;
     }
 
-    public void addTti(StlTti tti) {
+    public void addTti(StlTti tti, boolean ignoreTcf) {
         this.ttis.add(tti);
 
         // Create cue from tti
@@ -57,7 +57,9 @@ public class StlObject extends BaseSubtitleObject {
         }
 
         // Adjust start and end time depending on GSI Tcf
-        cue.subtractTime(this.gsi.getTcf());
+        if(!ignoreTcf) {
+            cue.subtractTime(this.gsi.getTcf());
+        }
 
         // Create cue region
         // Use tti vertical position

--- a/src/main/java/fr/noop/subtitle/stl/StlParser.java
+++ b/src/main/java/fr/noop/subtitle/stl/StlParser.java
@@ -14,6 +14,7 @@ import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.CoderMalfunctionError;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -266,7 +267,13 @@ public class StlParser implements SubtitleParser {
         // Read TextField (TF)
         byte [] tfBytes = new byte[112];
         dis.readFully(tfBytes, 0, 112);
-        tti.setTf(new String(tfBytes, charset));
+        try {
+            tti.setTf(new String(tfBytes, charset));
+        } catch (CoderMalfunctionError e) {
+            // There exist some STL files in the wild, which contain userdata not parsable using the gsi charset
+            // this is the case for some kinds of software, which carry meta information in EBN-254 text fields
+            tti.setTf(new String(tfBytes));
+        }
 
         // TTI is fully parsed
         return tti;

--- a/src/main/java/fr/noop/subtitle/stl/StlParser.java
+++ b/src/main/java/fr/noop/subtitle/stl/StlParser.java
@@ -34,10 +34,14 @@ public class StlParser implements SubtitleParser {
     }
     
     public StlObject parse(InputStream is) throws SubtitleParsingException {
-    	return parse(is, true);
+    	return parse(is, true, false);
     }
 
     public StlObject parse(InputStream is, boolean strict) throws SubtitleParsingException {
+        return parse(is, strict, false);
+    }
+
+    public StlObject parse(InputStream is, boolean strict, boolean skipUserdataTf) throws SubtitleParsingException {
         BufferedInputStream bis = new BufferedInputStream(is);
         DataInputStream dis = new DataInputStream(bis);
 
@@ -64,7 +68,9 @@ public class StlParser implements SubtitleParser {
                 throw new SubtitleParsingException("Unable to parse tti block");
             }
 
-            stl.addTti(tti);
+            if (!skipUserdataTf || tti.getEbn() != 254) {
+                stl.addTti(tti);
+            }
         }
 
         return stl;

--- a/src/main/java/fr/noop/subtitle/stl/StlParser.java
+++ b/src/main/java/fr/noop/subtitle/stl/StlParser.java
@@ -34,14 +34,18 @@ public class StlParser implements SubtitleParser {
     }
     
     public StlObject parse(InputStream is) throws SubtitleParsingException {
-    	return parse(is, true, false);
+    	return parse(is, true, false, false);
     }
 
-    public StlObject parse(InputStream is, boolean strict) throws SubtitleParsingException {
-        return parse(is, strict, false);
+    public StlObject parse(InputStream is,
+                           boolean strict) throws SubtitleParsingException {
+        return parse(is, strict, false, false);
     }
 
-    public StlObject parse(InputStream is, boolean strict, boolean skipUserdataTf) throws SubtitleParsingException {
+    public StlObject parse(InputStream is,
+                           boolean strict,
+                           boolean skipUserdataTf,
+                           boolean ignoreTcf) throws SubtitleParsingException {
         BufferedInputStream bis = new BufferedInputStream(is);
         DataInputStream dis = new DataInputStream(bis);
 
@@ -69,7 +73,7 @@ public class StlParser implements SubtitleParser {
             }
 
             if (!skipUserdataTf || tti.getEbn() != 254) {
-                stl.addTti(tti);
+                stl.addTti(tti, ignoreTcf);
             }
         }
 


### PR DESCRIPTION
There exist some STL files in the wild, which contain userdata not parsable using the charset from `GSI`. This is the case for some kinds of software, which carry meta information in EBN-254 text fields. This is intended to make the `StlParser` usable, even if producers of subtitles incorrectly implement the EBU STL standard.

Also, under certain circumstances, the `TCF` offset (in `GSI`) should not automatically be subtracted from subtitle cue timing. The EBU STL spec is not very strict concerning the later. One could also argue, that a "Parser" should not alter data in any kind, which the `StlParser` does, when subtracting TCF from cues start and end timestamps. In that case, the introduces flag should be defaulted to `true`, which in turn would break backwards compatibility.

**StlParser: Gracefully parse text field (TF)**

Fall back to default charset in case of `CoderMalfunctionError` when reading the `TF` String.

**StlParser: Flag to ignore Userdata**

Ignore EBN 254 Userdata if flag is set to true

**StlParser / StlObject: Flag to ignore TCF field**

Ignores `TCF` timestamp in `GSI` and subtracts nothing, if flag is set to true

**Also added .gitignore**